### PR TITLE
Update pap-env.sh

### DIFF
--- a/src/main/bash/pap-env.sh
+++ b/src/main/bash/pap-env.sh
@@ -43,7 +43,7 @@ PAP_PROVIDED_LIBS=$PAP_LIBS/provided
 PAP_CONF_FILE="$PAP_HOME/conf/pap_configuration.ini"
 
 # Sets the heap size for the JVM  
-if [ -z $PAP_JAVA_OPTS ]; then
+if [ -z "$PAP_JAVA_OPTS" ]; then
 	PAP_JAVA_OPTS="-Xmx256m "
 fi
 


### PR DESCRIPTION
$PAP_JAVA_OPTS should be quoted to prevent error messages when it's not empty and contains multiple options.
