### PR TITLE
Permit to unprivileged users to check PAP status

### DIFF
--- a/src/main/bash/papctl.sh
+++ b/src/main/bash/papctl.sh
@@ -21,8 +21,8 @@
 # Required-Stop:     $network $remote_fs
 # Default-Start:     3 4 5
 # Default-Stop:      0 1 6
-# Short-Description: The Argus PAP  
-# Description:       The Argus Policy Administration Point service 
+# Short-Description: The Argus PAP
+# Description:       The Argus Policy Administration Point service
 ### END INIT INFO
 #
 ### Chkconfig section
@@ -31,7 +31,7 @@
 # description: Argus PAP startup script
 # processname: argus-pap
 ###
-# 
+#
 set -e
 
 prog="$(basename $0)"
@@ -46,84 +46,91 @@ if [ -z $PAP_HOME ]; then
 	PAP_HOME="$(cd "${0%/*}/.." && pwd)"
 fi
 
-if [ ! -r $PAP_HOME/conf/pap_configuration.ini ]; then
-	echo "File $PAP_HOME/conf/pap_configuration.ini doesn't exist or is not readable!"
-	exit 1
-fi 
-	
 if [ -z $PAP_RUN_FILE ]; then
 	PAP_RUN_FILE=$PAP_HOME/.argus-pap.pid
 fi
 
-. $PAP_HOME/sbin/pap-env.sh
 
-pre_checks(){
+function pre_checks(){
 	check_openssl
 	check_certificates
 }
 
-success () {
+function _load_env() {
+	. $PAP_HOME/sbin/pap-env.sh
+}
+
+function _check_root_user() {
+    if [ `id -u` -ne 0 ]; then
+        echo "ERROR: You need root privileges to run this command"
+        exit 1
+    fi
+}
+
+function success () {
 	if [ ! -z "$1" ]; then
 		echo "$1"
 	fi
 	exit 0
 }
 
-failure () {
+function failure () {
 	if [ ! -z "$1" ]; then
 		echo "$1"
 	fi
 	exit 1
 }
 
-pap_pid(){
+function pap_pid(){
 
 	if test ! -f $PAP_RUN_FILE; then
 		echo "No pid file found for $prog!"
 		failure
 	fi
-	
+
 	PAP_PID=`head -n 1 $PAP_RUN_FILE`
-	
+
 }
 
-kill_pap_proc(){
-
+function kill_pap_proc(){
 	status
 	if [ $? -eq 0 ]; then
+
+		_load_env
+
 		## pap process is running
 		pid=`head -1 $PAP_RUN_FILE`
-		
+
 		## Use shutdown service hook
 		$PAP_SHUTDOWN_CMD
-		
+
 		if [ $? -ne 0 ]; then
 			echo "Error shutting down PAP service! Will kill the process..."
-			
+
 			kill -9 $pid
-			
+
 			if [ $? -ne 0 ]; then
 				failure "Error killing the PAP service... maybe you don't have the permissions to kill it!"
 			else
 				## remove pid file
 				rm $PAP_RUN_FILE
 			fi
-			
+
 		else
 			## remove pid file
 			rm $PAP_RUN_FILE
 		fi
 	else
 		failure "PAP  server is not running!"
-	fi 
+	fi
 }
-	
-status(){
+
+function status(){
 
 	if [ -f $PAP_RUN_FILE ]; then
 		pid=`head -1 $PAP_RUN_FILE`
 		ps -p $pid >/dev/null 2>&1
-		
+
 		if [ $? -ne 0 ]; then
 			echo "PAP not running...removing stale pid file"
 			rm $PAP_RUN_FILE
@@ -132,7 +139,7 @@ status(){
 			return 0
 		fi
 	else
-		## No PID file found, check that there is no PAP running 
+		## No PID file found, check that there is no PAP running
 		## without PID...
 		pid=`ps -efww | grep 'java.*PAPServer' | grep -v grep | awk '{print $2}'`
 		if [ -z $pid ]; then
@@ -149,7 +156,8 @@ status(){
 }
 
 
-alive_and_kicking(){
+function alive_and_kicking(){
+	_load_env
 
 	$PAP_HOME/bin/pap-admin ping -host $PAP_HOST -port $PAP_PORT -cert $PAP_CERT -key $PAP_KEY >/dev/null 2>&1
 	if [ $? -eq 0 ]; then
@@ -161,31 +169,39 @@ alive_and_kicking(){
 	fi
 }
 
-start(){
+function start(){
+	_check_root_user
+	_load_env
 
 	# echo -n "Starting $prog: "
-	
+
 	status && failure "PAP already running..."
-	
+
 	$PAP_CMD &
-	
+
 	if [ $? -eq 0 ]; then
 		echo "$!" > $PAP_RUN_FILE;
 		status || failure "PAP not running after being just started!"
-	 	success 
+	 	success
 	else
 		failure "failed!"
 	fi
-		
+
 }
 
-restart(){
-	
+function restart(){
+	_check_root_user
+	_load_env
+
 	# echo -n "Restarting $prog: "
 	kill_pap_proc && (rm -f $PAP_RUN_FILE; sleep 5; start) || failure "Error restarting pap process!"
 
 }
-stop(){
+
+function stop(){
+	_check_root_user
+	_load_env
+
 	# echo -n "Stopping $prog: "
 	kill_pap_proc && (rm -f $PAP_RUN_FILE; success "Ok.") || failure "Error killing PAP process!"
 }
@@ -194,15 +210,15 @@ case "$1" in
 	start)
 		start
 		;;
-	
+
 	stop)
 		stop
 		;;
-	
+
 	status)
 		status && success "PAP running!" || failure "PAP not running!"
 		;;
-	
+
 	restart)
 		restart
 		;;


### PR DESCRIPTION
Bug from GGUS: https://ggus.eu/index.php?mode=ticket_info&ticket_id=100322

Refactory of papcrl.sh script, with the goal of harmonize it with PDP and PED scripts.
Main changes:
- add function _check_root_user();
- add function _load_env();
- these two function are called in start/stop, but not in "status" command, so every unprivileged users can check PAP status.
