### PR TITLE
Removed support for switching OS or provided voms/canl/bc libraries.

### DIFF
--- a/src/main/bash/pap-admin-env.sh
+++ b/src/main/bash/pap-admin-env.sh
@@ -18,13 +18,8 @@
 
 
 # This script sets up the environment to run the pap admin CLI.
-# 
+#
 set -e
-
-# OS dependency flags
-[ -z "$PAP_USE_OS_CANL" ] && PAP_USE_OS_CANL="false"
-[ -z "$PAP_USE_OS_BC" ] && PAP_USE_OS_BC="false"
-[ -z "$PAP_USE_OS_VOMS" ] && PAP_USE_OS_VOMS="false"
 
 # Location of the PAP jars
 PAP_LIBS=$PAP_HOME/lib
@@ -41,32 +36,20 @@ PAP_CLIENT_CLASS="org.glite.authz.pap.ui.cli.PAPCLI"
 # ':' separated list of client PAP dependencies, used to build the classpath
 PAP_CLIENT_DEPS=$(ls -x $PAP_LIBS/*.jar | tr '\n' ':' | sed 's/:$//')
 
-# Include CANL from OS or embedded dir
-if [ "$PAP_USE_OS_CANL" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/canl-*.jar; do
-        [ -f $jar ] && PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
-    done
-else
-    PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$OS_JAR_DIR/canl.jar"
-fi
+# Include CANL from embedded dir
+for jar in $PAP_PROVIDED_LIBS/canl-*.jar; do
+    [ -f $jar ] && PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
+done
 
-# Include BC from OS or embedded dir
-if [ "$PAP_USE_OS_BC" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/bcpkix*.jar $PAP_PROVIDED_LIBS/bcprov*.jar; do
-        [ -f $jar ] &&  PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
-    done
-else
-    PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$OS_JAR_DIR/bcprov.jar:$OS_JAR_DIR/bcpkix.jar"
-fi
+# Include BC from embedded dir
+for jar in $PAP_PROVIDED_LIBS/bcpkix*.jar $PAP_PROVIDED_LIBS/bcprov*.jar; do
+    [ -f $jar ] &&  PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
+done
 
-# Include VOMS from OS or embedded dir
-if [ "$PAP_USE_OS_VOMS" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/voms-api-java-*.jar; do
-      [ -f $jar ] && PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
-    done
-else
-    PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$OS_JAR_DIR/voms-api-java3.jar"
-fi
+# Include VOMS from embedded dir
+for jar in $PAP_PROVIDED_LIBS/voms-api-java-*.jar; do
+  [ -f $jar ] && PAP_CLIENT_DEPS="$PAP_CLIENT_DEPS:$jar"
+done
 
 # Location of the PAP jar file
 PAP_JAR="$PAP_HOME/lib/pap.jar"

--- a/src/main/bash/pap-env.sh
+++ b/src/main/bash/pap-env.sh
@@ -17,15 +17,10 @@
 #
 
 # This script sets up the environment for the PAP service.
-# 
+#
 # DO NOT CHANGE THE CONTENT OF THIS FILE UNLESS YOU REALLY KNOW WHAT YOU ARE DOING
 #
 set -e
-
-# OS dependency flags
-[ -z "$PAP_USE_OS_CANL" ] && PAP_USE_OS_CANL="false"
-[ -z "$PAP_USE_OS_BC" ] && PAP_USE_OS_BC="false"
-[ -z "$PAP_USE_OS_VOMS" ] && PAP_USE_OS_VOMS="false"
 
 # Set the directory where we will look for jar packages coming from the OS
 [ -z "$OS_JAR_DIR" ] && OS_JAR_DIR="/usr/share/java"
@@ -42,7 +37,7 @@ PAP_PROVIDED_LIBS=$PAP_LIBS/provided
 # PAP configuration file location
 PAP_CONF_FILE="$PAP_HOME/conf/pap_configuration.ini"
 
-# Sets the heap size for the JVM  
+# Sets the heap size for the JVM
 if [ -z "$PAP_JAVA_OPTS" ]; then
 	PAP_JAVA_OPTS="-Xmx256m "
 fi
@@ -56,32 +51,20 @@ PAP_SHUTDOWN_CLASS="org.glite.authz.pap.server.standalone.ShutdownClient"
 # ':' separated list of  PAP dependencies, used to build the classpath
 PAP_DEPS=$(ls -x $PAP_LIBS/*.jar | tr '\n' ':'| sed 's/:$//')
 
-# Include CANL from OS or embedded dir
-if [ "$PAP_USE_OS_CANL" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/canl-*.jar; do
-        [ -f $jar ] && PAP_DEPS="$PAP_DEPS:$jar"
-    done
-else
-    PAP_DEPS="$PAP_DEPS:$OS_JAR_DIR/canl.jar"
-fi
+# Include CANL from embedded dir
+for jar in $PAP_PROVIDED_LIBS/canl-*.jar; do
+    [ -f $jar ] && PAP_DEPS="$PAP_DEPS:$jar"
+done
 
-# Include BC from OS or embedded dir
-if [ "$PAP_USE_OS_BC" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/bcpkix*.jar $PAP_PROVIDED_LIBS/bcprov*.jar; do
-        [ -f $jar ] &&  PAP_DEPS="$PAP_DEPS:$jar"
-    done
-else
-    PAP_DEPS="$PAP_DEPS:$OS_JAR_DIR/bcprov.jar:$OS_JAR_DIR/bcpkix.jar"
-fi
+# Include BC from embedded dir
+for jar in $PAP_PROVIDED_LIBS/bcpkix*.jar $PAP_PROVIDED_LIBS/bcprov*.jar; do
+    [ -f $jar ] &&  PAP_DEPS="$PAP_DEPS:$jar"
+done
 
-# Include VOMS from OS or embedded dir
-if [ "$PAP_USE_OS_VOMS" = "false" ]; then
-    for jar in $PAP_PROVIDED_LIBS/voms-api-java-*.jar; do
-      [ -f $jar ] && PAP_DEPS="$PAP_DEPS:$jar"
-    done
-else
-    PAP_DEPS="$PAP_DEPS:$OS_JAR_DIR/voms-api-java3.jar"
-fi
+# Include VOMS from embedded dir
+for jar in $PAP_PROVIDED_LIBS/voms-api-java-*.jar; do
+  [ -f $jar ] && PAP_DEPS="$PAP_DEPS:$jar"
+done
 
 # Location of the PAP jar file
 PAP_JAR="$PAP_HOME/lib/pap.jar"


### PR DESCRIPTION
I've removed conditional statements used for build the classpath: now, only provided jars are included, ignoring OS jars.
