### PR TITLE
Add force kill when service shutdown hook fail.

### DIFF
--- a/src/main/bash/papctl.sh
+++ b/src/main/bash/papctl.sh
@@ -117,6 +117,11 @@ function kill_pap_proc(){
 			fi
 
 		else
+			# Still running? Force kill
+			if [ `ps --pid $pid | grep -c $pid` -eq 1 ]; then
+				kill -KILL $pid
+			fi
+
 			## remove pid file
 			rm $PAP_RUN_FILE
 		fi


### PR DESCRIPTION
Edit init script, adding a command for force kill when shutdown service hook fail with exit status=0
