### PR TITLE
Add two new attributes

### DIFF
--- a/src/main/config/attribute-mappings.ini
+++ b/src/main/config/attribute-mappings.ini
@@ -31,6 +31,18 @@ pfqan.xacml-datatype = http://glite.org/xacml/datatype/fqan
 pfqan.xacml-target-element = subject
 pfqan.xacml-match-function = http://glite.org/xacml/algorithm/fqan-match
 
+id = ca-policy-oid
+ca-policy-oid.xacml-id = http://authz-interop.org/xacml/subject/ca-policy-oid
+ca-policy-oid.xacml-datatype = http://www.w3.org/2001/XMLSchema#string
+ca-policy-oid.xacml-target-element = subject
+ca-policy-oid.xacml-match-function = urn:oasis:names:tc:xacml:1.0:function:string-equal
+
+id = ca-policy-names
+ca-policy-names.xacml-id = http://authz-interop.org/xacml/subject/ca-policy-names
+ca-policy-names.xacml-datatype = http://www.w3.org/2001/XMLSchema#string
+ca-policy-names.xacml-target-element = subject
+ca-policy-names.xacml-match-function = urn:oasis:names:tc:xacml:1.0:function:string-equal
+
 id = resource
 resource.xacml-id = urn:oasis:names:tc:xacml:1.0:resource:resource-id
 resource.xacml-datatype = http://www.w3.org/2001/XMLSchema#string


### PR DESCRIPTION
Adding two new attributes to the attribute-mappings file. This is the required PAP side change for the additions explained in issue https://github.com/argus-authz/argus-pep-server/issues/15 and corresponding pull requests https://github.com/argus-authz/argus-pep-server/pull/16 and https://github.com/argus-authz/pkg.argus/pull/4
